### PR TITLE
Update template.yml - fix Enum.swift file path

### DIFF
--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -43,7 +43,7 @@ templateFiles:
   - path: Sources/AnyCodable.swift
   - path: Podspec.podspec
     destination: "{{ options.name }}.podspec"
-  - path: Sources/enum.swift
+  - path: Sources/Enum.swift
     context: enums
     destination: "Sources/Enums/{{ enumName }}.swift"
   - path: Sources/Model.swift


### PR DESCRIPTION
When running gwaggen in docker with case-sensitive filesystem it's failing to locate `Sources/enum.swift`. 