### PR TITLE
TT-97 namespacing issue

### DIFF
--- a/Specs/Petstore/generated/Swift/Sources/API.swift
+++ b/Specs/Petstore/generated/Swift/Sources/API.swift
@@ -5,8 +5,9 @@
 
 import Foundation
 
-public struct Petstore {
+public let version = "1.0.0"
 
+public struct Config {
     /// Whether to discard any errors when decoding optional properties
     public static var safeOptionalDecoding = false
 
@@ -15,22 +16,21 @@ public struct Petstore {
 
     /// Used to encode Dates when uses as string params
     public static let dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
-
-    public static let version = "1.0.0"
-
-    public enum Pets {}
-
-    public enum Server {
-
-        /** Test environment **/
-        public static func test(space: String = "main", version: String = "v1") -> String {
-            var url = "https://test.petstore.com/{version}/{space}"
-            url = url.replacingOccurrences(of: "{\(space)}", with: space)
-            url = url.replacingOccurrences(of: "{\(version)}", with: version)
-            return url
-        }
-
-        /** Prod environment **/
-        public static let prod = "http://petstore.swagger.io/v1"
-    }
 }
+
+public enum Server {
+
+    /** Test environment **/
+    public static func test(space: String = "main", version: String = "v1") -> String {
+        var url = "https://test.petstore.com/{version}/{space}"
+        url = url.replacingOccurrences(of: "{\(space)}", with: space)
+        url = url.replacingOccurrences(of: "{\(version)}", with: version)
+        return url
+    }
+
+    /** Prod environment **/
+    public static let prod = "http://petstore.swagger.io/v1"
+}
+
+/// Tags
+public enum Pets {}

--- a/Specs/Petstore/generated/Swift/Sources/Coding.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Coding.swift
@@ -111,7 +111,7 @@ extension KeyedDecodingContainer {
         do {
             container = try nestedUnkeyedContainer(forKey: key)
         } catch {
-            if Petstore.safeArrayDecoding {
+            if Config.safeArrayDecoding {
                 return array
             } else {
                 throw error
@@ -123,7 +123,7 @@ extension KeyedDecodingContainer {
                 let element = try container.decode(T.self)
                 array.append(element)
             } catch {
-                if Petstore.safeArrayDecoding {
+                if Config.safeArrayDecoding {
                     // hack to advance the current index
                     _ = try? container.decode(AnyCodable.self)
                 } else {
@@ -145,7 +145,7 @@ extension KeyedDecodingContainer {
     }
 
     fileprivate func decodeOptional<T>(_ closure: () throws -> T? ) throws -> T? {
-        if Petstore.safeOptionalDecoding {
+        if Config.safeOptionalDecoding {
             do {
                 return try closure()
             } catch {
@@ -295,7 +295,7 @@ extension DateDay {
 
 extension Date {
     func encode() -> Any {
-        return Petstore.dateEncodingFormatter.string(from: self)
+        return Config.dateEncodingFormatter.string(from: self)
     }
 }
 
@@ -323,7 +323,7 @@ extension Dictionary where Key == String, Value: RawRepresentable {
     }
 }
 
-extension UUID {
+extension Foundation.UUID {
     func encode() -> Any {
         return uuidString
     }

--- a/Specs/Petstore/generated/Swift/Sources/Requests/Pets/CreatePets.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Requests/Pets/CreatePets.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Petstore.Pets {
+extension Pets {
 
     /** Create a pet */
     public enum CreatePets {

--- a/Specs/Petstore/generated/Swift/Sources/Requests/Pets/ListPets.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Requests/Pets/ListPets.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Petstore.Pets {
+extension Pets {
 
     /** List all pets */
     public enum ListPets {

--- a/Specs/Petstore/generated/Swift/Sources/Requests/Pets/ShowPetById.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Requests/Pets/ShowPetById.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Petstore.Pets {
+extension Pets {
 
     /** Info for a specific pet */
     public enum ShowPetById {

--- a/Specs/Petstore/generated/Swift/Sources/Requests/Pets/UpdatePetWithForm.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Requests/Pets/UpdatePetWithForm.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Petstore.Pets {
+extension Pets {
 
     /** Updates a pet in the store with form data */
     public enum UpdatePetWithForm {

--- a/Specs/PetstoreTest/generated/Swift/Sources/API.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/API.swift
@@ -6,8 +6,9 @@
 import Foundation
 
 /** This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. */
-public struct PetstoreTest {
+public let version = "1.0.0"
 
+public struct Config {
     /// Whether to discard any errors when decoding optional properties
     public static var safeOptionalDecoding = false
 
@@ -16,16 +17,15 @@ public struct PetstoreTest {
 
     /// Used to encode Dates when uses as string params
     public static let dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
-
-    public static let version = "1.0.0"
-
-    public enum Fake {}
-    public enum Pet {}
-    public enum Store {}
-    public enum User {}
-
-    public enum Server {
-
-        public static let main = "http://petstore.swagger.io:80/v2"
-    }
 }
+
+public enum Server {
+
+    public static let main = "http://petstore.swagger.io:80/v2"
+}
+
+/// Tags
+public enum Fake {}
+public enum Pet {}
+public enum Store {}
+public enum User {}

--- a/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
@@ -111,7 +111,7 @@ extension KeyedDecodingContainer {
         do {
             container = try nestedUnkeyedContainer(forKey: key)
         } catch {
-            if PetstoreTest.safeArrayDecoding {
+            if Config.safeArrayDecoding {
                 return array
             } else {
                 throw error
@@ -123,7 +123,7 @@ extension KeyedDecodingContainer {
                 let element = try container.decode(T.self)
                 array.append(element)
             } catch {
-                if PetstoreTest.safeArrayDecoding {
+                if Config.safeArrayDecoding {
                     // hack to advance the current index
                     _ = try? container.decode(AnyCodable.self)
                 } else {
@@ -145,7 +145,7 @@ extension KeyedDecodingContainer {
     }
 
     fileprivate func decodeOptional<T>(_ closure: () throws -> T? ) throws -> T? {
-        if PetstoreTest.safeOptionalDecoding {
+        if Config.safeOptionalDecoding {
             do {
                 return try closure()
             } catch {
@@ -295,7 +295,7 @@ extension DateDay {
 
 extension Date {
     func encode() -> Any {
-        return PetstoreTest.dateEncodingFormatter.string(from: self)
+        return Config.dateEncodingFormatter.string(from: self)
     }
 }
 
@@ -323,7 +323,7 @@ extension Dictionary where Key == String, Value: RawRepresentable {
     }
 }
 
-extension UUID {
+extension Foundation.UUID {
     func encode() -> Any {
         return uuidString
     }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestClientModel.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestClientModel.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Fake {
+extension Fake {
 
     /** To test "client" model */
     public enum TestClientModel {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEndpointParameters.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEndpointParameters.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Fake {
+extension Fake {
 
     /** Fake endpoint for testing various parameters
 假端點

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEnumParameters.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEnumParameters.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Fake {
+extension Fake {
 
     /** To test enum parameters */
     public enum TestEnumParameters {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/AddPet.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/AddPet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /** Add a new pet to the store */
     public enum AddPet {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/DeletePet.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/DeletePet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /** Deletes a pet */
     public enum DeletePet {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/FindPetsByStatus.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/FindPetsByStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /**
     Finds Pets by status

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/FindPetsByTags.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/FindPetsByTags.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /**
     Finds Pets by tags

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/GetPetById.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/GetPetById.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /**
     Find pet by ID

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UpdatePet.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UpdatePet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /** Update an existing pet */
     public enum UpdatePet {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UpdatePetWithForm.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UpdatePetWithForm.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /** Updates a pet in the store with form data */
     public enum UpdatePetWithForm {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UploadFile.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UploadFile.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Pet {
+extension Pet {
 
     /** uploads an image */
     public enum UploadFile {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/DeleteOrder.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/DeleteOrder.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Store {
+extension Store {
 
     /**
     Delete purchase order by ID

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/GetInventory.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/GetInventory.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Store {
+extension Store {
 
     /**
     Returns pet inventories by status

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/GetOrderById.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/GetOrderById.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Store {
+extension Store {
 
     /**
     Find purchase order by ID

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/PlaceOrder.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/PlaceOrder.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.Store {
+extension Store {
 
     /** Place an order for a pet */
     public enum PlaceOrder {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUser.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUser.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /**
     Create user

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithArrayInput.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithArrayInput.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /** Creates list of users with given input array */
     public enum CreateUsersWithArrayInput {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithListInput.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithListInput.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /** Creates list of users with given input array */
     public enum CreateUsersWithListInput {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/DeleteUser.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/DeleteUser.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /**
     Delete user

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/GetUserByName.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/GetUserByName.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /** Get user by user name */
     public enum GetUserByName {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/LoginUser.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/LoginUser.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /** Logs user into the system */
     public enum LoginUser {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/LogoutUser.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/LogoutUser.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /** Logs out current logged in user session */
     public enum LogoutUser {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/UpdateUser.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/UpdateUser.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension PetstoreTest.User {
+extension User {
 
     /**
     Updated user

--- a/Specs/Rocket/generated/Swift/Sources/API.swift
+++ b/Specs/Rocket/generated/Swift/Sources/API.swift
@@ -10,8 +10,9 @@ This in turn makes client integration easier and reduces the complexity and size
 Rocket is also customisable - allowing UI engineers to ‘remix’ the existing back-end services into something that
 best suits the application they are developing.
  */
-public struct Rocket {
+public let version = "1.0.0"
 
+public struct Config {
     /// Whether to discard any errors when decoding optional properties
     public static var safeOptionalDecoding = false
 
@@ -20,19 +21,18 @@ public struct Rocket {
 
     /// Used to encode Dates when uses as string params
     public static let dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
-
-    public static let version = "1.0.0"
-
-    public enum Account {}
-    public enum App {}
-    public enum Authorization {}
-    public enum Content {}
-    public enum Profile {}
-    public enum Registration {}
-    public enum Support {}
-
-    public enum Server {
-
-        public static let main = "/"
-    }
 }
+
+public enum Server {
+
+    public static let main = "/"
+}
+
+/// Tags
+public enum Account {}
+public enum App {}
+public enum Authorization {}
+public enum Content {}
+public enum Profile {}
+public enum Registration {}
+public enum Support {}

--- a/Specs/Rocket/generated/Swift/Sources/Coding.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Coding.swift
@@ -111,7 +111,7 @@ extension KeyedDecodingContainer {
         do {
             container = try nestedUnkeyedContainer(forKey: key)
         } catch {
-            if Rocket.safeArrayDecoding {
+            if Config.safeArrayDecoding {
                 return array
             } else {
                 throw error
@@ -123,7 +123,7 @@ extension KeyedDecodingContainer {
                 let element = try container.decode(T.self)
                 array.append(element)
             } catch {
-                if Rocket.safeArrayDecoding {
+                if Config.safeArrayDecoding {
                     // hack to advance the current index
                     _ = try? container.decode(AnyCodable.self)
                 } else {
@@ -145,7 +145,7 @@ extension KeyedDecodingContainer {
     }
 
     fileprivate func decodeOptional<T>(_ closure: () throws -> T? ) throws -> T? {
-        if Rocket.safeOptionalDecoding {
+        if Config.safeOptionalDecoding {
             do {
                 return try closure()
             } catch {
@@ -295,7 +295,7 @@ extension DateDay {
 
 extension Date {
     func encode() -> Any {
-        return Rocket.dateEncodingFormatter.string(from: self)
+        return Config.dateEncodingFormatter.string(from: self)
     }
 }
 
@@ -323,7 +323,7 @@ extension Dictionary where Key == String, Value: RawRepresentable {
     }
 }
 
-extension UUID {
+extension Foundation.UUID {
     func encode() -> Any {
         return uuidString
     }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePassword.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Change the password of an account. */
     public enum ChangePassword {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePin.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePin.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Change the pin of an account. */
     public enum ChangePin {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/CreateProfile.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/CreateProfile.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Create a new profile under the active account. */
     public enum CreateProfile {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/DeleteProfileWithId.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/DeleteProfileWithId.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Delete a profile with a specific id under the active account.
 Note that you cannot delete the primary profile.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/DeregisterDevice.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/DeregisterDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Deregister a playback device from an account. */
     public enum DeregisterDevice {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetAccount.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetAccount.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Get the details of an account along with the profiles and entitlements under it. */
     public enum GetAccount {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetDevice.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Get a registered device. */
     public enum GetDevice {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetDevices.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetDevices.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Get all devices registered under this account.
 Also includes information around device registration and deregistration limits.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetEntitlements.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetEntitlements.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Get all entitlements under the account.
 This list is returned under the call to get account information so a call here is

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFiles.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFiles.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Get the video files associated with an item given maximum resolution, device type
 and one or more delivery types.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFilesGuarded.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFilesGuarded.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Get the video files associated with an item given maximum resolution, device type
 and one or more delivery types.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetProfileWithId.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetProfileWithId.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Get the summary of a profile with a specific id under the active account. */
     public enum GetProfileWithId {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/RegisterDevice.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/RegisterDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Register a playback device under an account.
 If a device with the same id already exists a `409` conflict will be returned.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/RenameDevice.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/RenameDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Rename a device */
     public enum RenameDevice {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/RequestEmailVerification.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/RequestEmailVerification.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Request that the email address tied to an account be verified.
 This will send a verification email to the email address of the primary profile containing

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateAccount.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateAccount.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Update the details of an account.
 This supports partial updates so you can send just the properties you wish to update.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateProfileWithId.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateProfileWithId.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Account {
+extension Account {
 
     /** Update the summary of a profile with a specific id under the active account.
 This supports partial updates so you can send just the properties you wish to update.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/App/GetAppConfig.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/App/GetAppConfig.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.App {
+extension App {
 
     /** Get the global configuration for an application. Should be called during app statup.
 This includes things like device and playback rules, classifications,

--- a/Specs/Rocket/generated/Swift/Sources/Requests/App/GetPage.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/App/GetPage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.App {
+extension App {
 
     /** Returns a page with the specified id.
 If targeting the search page you must url encode the search term as a parameter

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetAccountToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetAccountToken.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Authorization {
+extension Authorization {
 
     /** Request one or more `Account` level authorization tokens each with a chosen scope.
 Tokens are used to access restricted service endpoints. These restricted endpoints

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetProfileToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetProfileToken.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Authorization {
+extension Authorization {
 
     /** Request one or more `Profile` level authorization tokens each with a chosen scope.
 Tokens are used to access restricted service endpoints. These restriced endpoints

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/RefreshToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/RefreshToken.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Authorization {
+extension Authorization {
 
     /** Refresh an account or profile level authorization token which is marked as refreshable. */
     public enum RefreshToken {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/SignOut.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/SignOut.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Authorization {
+extension Authorization {
 
     /** When a user signs out of an application we need to clear some
 basic cookies we assigned them during token authorization.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItem.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItem.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Returns the details of an item with the specified id. */
     public enum GetItem {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemChildrenList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemChildrenList.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Returns the List of child summary items under an item.
 If the item is a Season then the children will be episodes and ordered by episode number.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemRelatedList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemRelatedList.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Returns the list of items related to the parent item.
 Note for now, due to the size of the list being unknown, only a single page will be returned.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetList.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Returns a list of items under the specified item list */
     public enum GetList {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetLists.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetLists.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Returns an array of item lists with their first page of content resolved. */
     public enum GetLists {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPlan.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPlan.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Returns the details of a Plan with the specified id. */
     public enum GetPlan {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPublicItemMediaFiles.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPublicItemMediaFiles.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Get the free / public video files associated with an item given maximum resolution,
 device type and one or more delivery types.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetSchedules.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetSchedules.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Returns schedules for a defined set of channels over a requested period.
 Schedules are requested in hour blocks and returned grouped by the channel

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/Search.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/Search.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Content {
+extension Content {
 
     /** Search the catalog of items and people. */
     public enum Search {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/BookmarkItem.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/BookmarkItem.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Bookmark an item under the active profile.
 Creates one if it doesn't exist, overwrites one if it does.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/DeleteItemBookmark.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/DeleteItemBookmark.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Unbookmark an item under the active profile. */
     public enum DeleteItemBookmark {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetBookmarkList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetBookmarkList.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Returns the list of bookmarked items under the active profile. */
     public enum GetBookmarkList {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetBookmarks.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetBookmarks.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Get the map of bookmarked item ids (itemId => creationDate) under the active profile. */
     public enum GetBookmarks {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetItemBookmark.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetItemBookmark.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Get the bookmark for an item under the active profile. */
     public enum GetItemBookmark {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetItemRating.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetItemRating.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Get the rating info for an item under the active profile. */
     public enum GetItemRating {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetItemWatchedStatus.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetItemWatchedStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Get the watched status info for an item under the active profile. */
     public enum GetItemWatchedStatus {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetProfile.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetProfile.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Get the details of the active profile, including watched, bookmarked and rated items. */
     public enum GetProfile {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatings.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatings.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Get the map of rated item ids (itemId => rating out of 10) under the active profile. */
     public enum GetRatings {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatingsList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatingsList.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Returns the list of rated items under the active profile. */
     public enum GetRatingsList {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatched.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatched.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Get the map of watched item ids (itemId => last playhead position) under the active profile. */
     public enum GetWatched {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatchedList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatchedList.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Returns the list of watched items under the active profile. */
     public enum GetWatchedList {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/RateItem.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/RateItem.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Rate an item under the active profile.
 Creates one if it doesn't exist, overwrites one if it does.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/SetItemWatchedStatus.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/SetItemWatchedStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Profile {
+extension Profile {
 
     /** Record the watched playhead position of a video under the active profile.
 Can be used later to resume a video from where it was last watched.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Registration/Register.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Registration/Register.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Registration {
+extension Registration {
 
     /** Register a new user, creating them an account.
 Registration, when successful, will return an array of access tokens so the user is

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/ForgotPassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/ForgotPassword.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Support {
+extension Support {
 
     /** Request the password of an account's primary profile be reset.
 Should be called when a user has forgotten their password.

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/ResetPassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/ResetPassword.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Support {
+extension Support {
 
     /** When a user requests to reset their password via the /request-password-reset endpoint, an
 email is sent to the email address of the primary profile of the account. This email contains a link

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/VerifyEmail.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/VerifyEmail.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension Rocket.Support {
+extension Support {
 
     /** When an account is created an email is sent to the email address of the new account.
 This contains a link, which once clicked, verifies the email address of the account is correct.

--- a/Specs/TBX/generated/Swift/Sources/API.swift
+++ b/Specs/TBX/generated/Swift/Sources/API.swift
@@ -5,8 +5,9 @@
 
 import Foundation
 
-public struct TBX {
+public let version = "2.4.1"
 
+public struct Config {
     /// Whether to discard any errors when decoding optional properties
     public static var safeOptionalDecoding = false
 
@@ -15,16 +16,15 @@ public struct TBX {
 
     /// Used to encode Dates when uses as string params
     public static let dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
-
-    public static let version = "2.4.1"
-
-    public enum AuthorizationService {}
-    public enum DeviceService {}
-    public enum UserService {}
-    public enum Auth {}
-
-    public enum Server {
-
-        public static let main = "/v2"
-    }
 }
+
+public enum Server {
+
+    public static let main = "/v2"
+}
+
+/// Tags
+public enum AuthorizationService {}
+public enum DeviceService {}
+public enum UserService {}
+public enum Auth {}

--- a/Specs/TBX/generated/Swift/Sources/Coding.swift
+++ b/Specs/TBX/generated/Swift/Sources/Coding.swift
@@ -111,7 +111,7 @@ extension KeyedDecodingContainer {
         do {
             container = try nestedUnkeyedContainer(forKey: key)
         } catch {
-            if TBX.safeArrayDecoding {
+            if Config.safeArrayDecoding {
                 return array
             } else {
                 throw error
@@ -123,7 +123,7 @@ extension KeyedDecodingContainer {
                 let element = try container.decode(T.self)
                 array.append(element)
             } catch {
-                if TBX.safeArrayDecoding {
+                if Config.safeArrayDecoding {
                     // hack to advance the current index
                     _ = try? container.decode(AnyCodable.self)
                 } else {
@@ -145,7 +145,7 @@ extension KeyedDecodingContainer {
     }
 
     fileprivate func decodeOptional<T>(_ closure: () throws -> T? ) throws -> T? {
-        if TBX.safeOptionalDecoding {
+        if Config.safeOptionalDecoding {
             do {
                 return try closure()
             } catch {
@@ -295,7 +295,7 @@ extension DateDay {
 
 extension Date {
     func encode() -> Any {
-        return TBX.dateEncodingFormatter.string(from: self)
+        return Config.dateEncodingFormatter.string(from: self)
     }
 }
 
@@ -323,7 +323,7 @@ extension Dictionary where Key == String, Value: RawRepresentable {
     }
 }
 
-extension UUID {
+extension Foundation.UUID {
     func encode() -> Any {
         return uuidString
     }

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthGenerateJavascript.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthGenerateJavascript.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Get Javascript SDK */
     public enum AuthGenerateJavascript {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthGetListOfMSO.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthGetListOfMSO.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Get list of IDPs of Content Provider */
     public enum AuthGetListOfMSO {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthLogin.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthLogin.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** URL for the client can start a new login with your IDP */
     public enum AuthLogin {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthLoginWithoutRedirect.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthLoginWithoutRedirect.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** This API is deprecated please use "login" without send the URL instead */
     public enum AuthLoginWithoutRedirect {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthLogout.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthLogout.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** URL for the client can start a logout with your IDP */
     public enum AuthLogout {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthOauth2Assert.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthOauth2Assert.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Return Url from OAuth2.0 login */
     public enum AuthOauth2Assert {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthReturnLogin.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthReturnLogin.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** This API is deprecated please use "login" without send the URL instead */
     public enum AuthReturnLogin {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlAssertGetAuthSamlAssert.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlAssertGetAuthSamlAssert.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Return Url from SAML login */
     public enum AuthSamlAssertGetAuthSamlAssert {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlAssertPostAuthSamlAssert.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlAssertPostAuthSamlAssert.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Return Url from SAML login */
     public enum AuthSamlAssertPostAuthSamlAssert {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlLogout.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlLogout.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Return url from SAML logout */
     public enum AuthSamlLogout {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlMetadata.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthSamlMetadata.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Contains information necessary for interaction with SAML-enabled identity or service providers */
     public enum AuthSamlMetadata {

--- a/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthStatus.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/Auth/AuthStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.Auth {
+extension Auth {
 
     /** Check user device status */
     public enum AuthStatus {

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceCreateRuleToOverrideResponse.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceCreateRuleToOverrideResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     /** Create a rule to override the IDP response's */
     public enum AuthorizationServiceCreateRuleToOverrideResponse {

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceCreateTryAndBuy.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceCreateTryAndBuy.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     public enum AuthorizationServiceCreateTryAndBuy {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceDeleteRuleToOverrideResponse.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceDeleteRuleToOverrideResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     /** Delete a rule to override the IDP response's */
     public enum AuthorizationServiceDeleteRuleToOverrideResponse {

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetAttributes.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetAttributes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     public enum AuthorizationServiceGetAttributes {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetRulesToOverrideResponse.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetRulesToOverrideResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     /** Get the list of rules to override the IDP response's */
     public enum AuthorizationServiceGetRulesToOverrideResponse {

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetTryAndBuy.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetTryAndBuy.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     public enum AuthorizationServiceGetTryAndBuy {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetUser.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceGetUser.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     public enum AuthorizationServiceGetUser {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceHasAccessTo.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceHasAccessTo.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     public enum AuthorizationServiceHasAccessTo {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceHasLogged.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceHasLogged.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.AuthorizationService {
+extension AuthorizationService {
 
     public enum AuthorizationServiceHasLogged {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceActivateDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceActivateDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceActivateDevice {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceCreateTryAndBuy.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceCreateTryAndBuy.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceCreateTryAndBuy {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceDeactivateDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceDeactivateDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceDeactivateDevice {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceGetDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceGetDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceGetDevice {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceHasLogged.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceHasLogged.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceHasLogged {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceListDevices.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceListDevices.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceListDevices {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceReactiveDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceReactiveDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceReactiveDevice {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceValidateCode.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/DeviceService/DeviceServiceValidateCode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.DeviceService {
+extension DeviceService {
 
     public enum DeviceServiceValidateCode {
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceAccess.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceAccess.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Check if the Customer has access to execute an action in many URNs */
     public enum UserServiceAccess {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCheckDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCheckDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Check if a Device exists and this is active */
     public enum UserServiceCheckDevice {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCreateDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCreateDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Create a new Device */
     public enum UserServiceCreateDevice {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCreateToken.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCreateToken.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Create a Token to automatically sing in a customer without pass to IDP login page */
     public enum UserServiceCreateToken {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCreateTryAndBuy.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceCreateTryAndBuy.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Create a Try and Buy to Customer and  optionally to a specific device */
     public enum UserServiceCreateTryAndBuy {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceDeviceAccess.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceDeviceAccess.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Check if the Device has access to execute an action in many URNs */
     public enum UserServiceDeviceAccess {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceDeviceHasAccessTo.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceDeviceHasAccessTo.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Check if the Device has access to execute an action with the URN */
     public enum UserServiceDeviceHasAccessTo {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetCustomerDevices.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetCustomerDevices.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Get Devices of Customer. */
     public enum UserServiceGetCustomerDevices {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Find a Device by device id */
     public enum UserServiceGetDevice {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetDeviceAttributes.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetDeviceAttributes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Get device data attributes by deviceToken */
     public enum UserServiceGetDeviceAttributes {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetToken.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetToken.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Get a Token */
     public enum UserServiceGetToken {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetTryAndBuy.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceGetTryAndBuy.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Get Try and Buy data by customerId */
     public enum UserServiceGetTryAndBuy {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceHasAccessTo.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceHasAccessTo.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Check if the Customer has access to execute an action with the URN */
     public enum UserServiceHasAccessTo {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogout.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogout.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Logout a related device by device id */
     public enum UserServiceLogout {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogoutAll.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogoutAll.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Logout all devices related to the customer */
     public enum UserServiceLogoutAll {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceRemoveUserCache.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceRemoveUserCache.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Clear user's authorization cache */
     public enum UserServiceRemoveUserCache {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceUpdateDevice.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceUpdateDevice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Update Device info */
     public enum UserServiceUpdateDevice {

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceUseToken.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceUseToken.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TBX.UserService {
+extension UserService {
 
     /** Use a Token */
     public enum UserServiceUseToken {

--- a/Specs/TFL/generated/Swift/Sources/API.swift
+++ b/Specs/TFL/generated/Swift/Sources/API.swift
@@ -5,8 +5,9 @@
 
 import Foundation
 
-public struct TFL {
+public let version = "v1"
 
+public struct Config {
     /// Whether to discard any errors when decoding optional properties
     public static var safeOptionalDecoding = false
 
@@ -15,26 +16,25 @@ public struct TFL {
 
     /// Used to encode Dates when uses as string params
     public static let dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
-
-    public static let version = "v1"
-
-    public enum AccidentStats {}
-    public enum AirQuality {}
-    public enum BikePoint {}
-    public enum Cabwise {}
-    public enum Journey {}
-    public enum Line {}
-    public enum Mode {}
-    public enum Occupancy {}
-    public enum Place {}
-    public enum Road {}
-    public enum Search {}
-    public enum StopPoint {}
-    public enum TravelTime {}
-    public enum Vehicle {}
-
-    public enum Server {
-
-        public static let main = "https://api.tfl.gov.uk"
-    }
 }
+
+public enum Server {
+
+    public static let main = "https://api.tfl.gov.uk"
+}
+
+/// Tags
+public enum AccidentStats {}
+public enum AirQuality {}
+public enum BikePoint {}
+public enum Cabwise {}
+public enum Journey {}
+public enum Line {}
+public enum Mode {}
+public enum Occupancy {}
+public enum Place {}
+public enum Road {}
+public enum Search {}
+public enum StopPoint {}
+public enum TravelTime {}
+public enum Vehicle {}

--- a/Specs/TFL/generated/Swift/Sources/Coding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Coding.swift
@@ -111,7 +111,7 @@ extension KeyedDecodingContainer {
         do {
             container = try nestedUnkeyedContainer(forKey: key)
         } catch {
-            if TFL.safeArrayDecoding {
+            if Config.safeArrayDecoding {
                 return array
             } else {
                 throw error
@@ -123,7 +123,7 @@ extension KeyedDecodingContainer {
                 let element = try container.decode(T.self)
                 array.append(element)
             } catch {
-                if TFL.safeArrayDecoding {
+                if Config.safeArrayDecoding {
                     // hack to advance the current index
                     _ = try? container.decode(AnyCodable.self)
                 } else {
@@ -145,7 +145,7 @@ extension KeyedDecodingContainer {
     }
 
     fileprivate func decodeOptional<T>(_ closure: () throws -> T? ) throws -> T? {
-        if TFL.safeOptionalDecoding {
+        if Config.safeOptionalDecoding {
             do {
                 return try closure()
             } catch {
@@ -295,7 +295,7 @@ extension DateDay {
 
 extension Date {
     func encode() -> Any {
-        return TFL.dateEncodingFormatter.string(from: self)
+        return Config.dateEncodingFormatter.string(from: self)
     }
 }
 
@@ -323,7 +323,7 @@ extension Dictionary where Key == String, Value: RawRepresentable {
     }
 }
 
-extension UUID {
+extension Foundation.UUID {
     func encode() -> Any {
         return uuidString
     }

--- a/Specs/TFL/generated/Swift/Sources/Requests/AccidentStats/AccidentStatsGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/AccidentStats/AccidentStatsGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.AccidentStats {
+extension AccidentStats {
 
     /** Gets all accident details for accidents occuring in the specified year */
     public enum AccidentStatsGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/AirQuality/AirQualityGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/AirQuality/AirQualityGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.AirQuality {
+extension AirQuality {
 
     /** Gets air quality data feed */
     public enum AirQualityGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/BikePoint/BikePointGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/BikePoint/BikePointGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.BikePoint {
+extension BikePoint {
 
     /** Gets the bike point with the given id. */
     public enum BikePointGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/BikePoint/BikePointGetAll.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/BikePoint/BikePointGetAll.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.BikePoint {
+extension BikePoint {
 
     /** Gets all bike point locations. The Place object has an addtionalProperties array which contains the nbBikes, nbDocks and nbSpaces
             numbers which give the status of the BikePoint. A mismatch in these numbers i.e. nbDocks - (nbBikes + nbSpaces) != 0 indicates broken docks. */

--- a/Specs/TFL/generated/Swift/Sources/Requests/BikePoint/BikePointSearch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/BikePoint/BikePointSearch.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.BikePoint {
+extension BikePoint {
 
     /** Search for bike stations by their name, a bike point's name often contains information about the name of the street
             or nearby landmarks, for example. Note that the search result does not contain the PlaceProperties i.e. the status

--- a/Specs/TFL/generated/Swift/Sources/Requests/Cabwise/CabwiseGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Cabwise/CabwiseGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Cabwise {
+extension Cabwise {
 
     /** Gets taxis and minicabs contact information */
     public enum CabwiseGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyJourneyResults.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyJourneyResults.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Journey {
+extension Journey {
 
     /** Perform a Journey Planner search from the parameters specified in simple types */
     public enum JourneyJourneyResults {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyMeta.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyMeta.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Journey {
+extension Journey {
 
     /** Gets a list of all of the available journey planner modes */
     public enum JourneyMeta {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineArrivals.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineArrivals.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Get the list of arrival predictions for given line ids based at the given stop */
     public enum GetLineArrivals {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineArrivalsByPath.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineArrivalsByPath.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Get the list of arrival predictions for given line ids based at the given stop going in the procided direction */
     public enum GetLineArrivalsByPath {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineStatus.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets the line status for given line ids during the provided dates e.g Minor Delays */
     public enum GetLineStatus {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineDisruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineDisruption.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Get disruptions for the given line ids */
     public enum LineDisruption {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineDisruptionByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineDisruptionByMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Get disruptions for all lines of the given modes. */
     public enum LineDisruptionByMode {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets lines that match the specified line ids. */
     public enum LineGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineGetByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineGetByMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets lines that serve the given modes. */
     public enum LineGetByMode {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Get all valid routes for given line ids, including the name and id of the originating and terminating stops for each route. */
     public enum LineLineRoutesByIds {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaDisruptionCategories.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaDisruptionCategories.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets a list of valid disruption categories */
     public enum LineMetaDisruptionCategories {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaModes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaModes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets a list of valid modes */
     public enum LineMetaModes {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaServiceTypes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaServiceTypes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets a list of valid ServiceTypes to filter on */
     public enum LineMetaServiceTypes {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaSeverity.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineMetaSeverity.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets a list of valid severity codes */
     public enum LineMetaSeverity {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Get all valid routes for all lines, including the name and id of the originating and terminating stops for each route. */
     public enum LineRoute {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets all lines and their valid routes for given modes, including the name and id of the originating and terminating stops for each route */
     public enum LineRouteByMode {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets all valid routes for given line id, including the sequence of stops on each route. */
     public enum LineRouteSequence {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Search for lines or routes matching the query string */
     public enum LineSearch {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStatusByIds.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStatusByIds.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets the line status of for given line ids e.g Minor Delays */
     public enum LineStatusByIds {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStatusByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStatusByMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets the line status of for all lines for the given modes */
     public enum LineStatusByMode {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStatusBySeverity.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStatusBySeverity.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets the line status for all lines with a given severity
             A list of valid severity codes can be obtained from a call to Line/Meta/Severity */

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStopPoints.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineStopPoints.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets a list of the stations that serve the given line id */
     public enum LineStopPoints {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineTimetable.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineTimetable.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets the timetable for a specified station on the give line */
     public enum LineTimetable {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineTimetableTo.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineTimetableTo.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Line {
+extension Line {
 
     /** Gets the timetable for a specified station on the give line with specified destination */
     public enum LineTimetableTo {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Mode/ModeArrivals.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Mode/ModeArrivals.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Mode {
+extension Mode {
 
     /** Gets the next arrival predictions for all stops of a given mode */
     public enum ModeArrivals {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Mode/ModeGetActiveServiceTypes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Mode/ModeGetActiveServiceTypes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Mode {
+extension Mode {
 
     /** Returns the service type active for a mode.
             Currently only supports tube */

--- a/Specs/TFL/generated/Swift/Sources/Requests/Occupancy/GetOccupant.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Occupancy/GetOccupant.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Occupancy {
+extension Occupancy {
 
     /** Gets the occupancy for a car park with a given id */
     public enum GetOccupant {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Occupancy/GetOccupants.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Occupancy/GetOccupants.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Occupancy {
+extension Occupancy {
 
     /** Gets the occupancy for all car parks that have occupancy data */
     public enum GetOccupants {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets the place with the given id. */
     public enum PlaceGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetAt.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetAt.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets any places of the given type whose geography intersects the given latitude and longitude. In practice this means the Place
             must be polygonal e.g. a BoroughBoundary. */

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetByGeoBox.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetByGeoBox.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets the places that lie within the bounding box defined by the lat/lon of its north-west and south-east corners. Optionally filters
             on type and can strip properties for a smaller payload. */

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetByType.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetByType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets all places of a given type */
     public enum PlaceGetByType {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetOverlay.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetOverlay.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets the place overlay for a given set of co-ordinates and a given width/height. */
     public enum PlaceGetOverlay {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetStreetsByPostCode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetStreetsByPostCode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets the set of streets associated with a post code. */
     public enum PlaceGetStreetsByPostCode {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceMetaCategories.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceMetaCategories.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets a list of all of the available place property categories and keys. */
     public enum PlaceMetaCategories {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceMetaPlaceTypes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceMetaPlaceTypes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets a list of the available types of Place. */
     public enum PlaceMetaPlaceTypes {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceSearch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceSearch.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Place {
+extension Place {
 
     /** Gets all places that matches the given query */
     public enum PlaceSearch {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoad.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoad.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Gets the road with the specified id (e.g. A1) */
     public enum GetRoad {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoadDisruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoadDisruption.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Get active disruptions, filtered by road ids */
     public enum GetRoadDisruption {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoads.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoads.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Gets all roads managed by TfL */
     public enum GetRoads {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadDisruptedStreets.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadDisruptedStreets.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Gets a list of disrupted streets. If no date filters are provided, current disruptions are returned. */
     public enum RoadDisruptedStreets {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadDisruptionById.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadDisruptionById.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Gets a list of active disruptions filtered by disruption Ids. */
     public enum RoadDisruptionById {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadMetaCategories.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadMetaCategories.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Gets a list of valid RoadDisruption categories */
     public enum RoadMetaCategories {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadMetaSeverities.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadMetaSeverities.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Gets a list of valid RoadDisruption severity codes */
     public enum RoadMetaSeverities {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadStatus.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/RoadStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Road {
+extension Road {
 
     /** Gets the specified roads with the status aggregated over the date range specified, or now until the end of today if no dates are passed. */
     public enum RoadStatus {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchBusSchedules.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchBusSchedules.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Search {
+extension Search {
 
     /** Searches the bus schedules folder on S3 for a given bus number. */
     public enum SearchBusSchedules {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Search {
+extension Search {
 
     /** Search the site for occurrences of the query string. The maximum number of results returned is equal to the maximum page size
             of 100. To return subsequent pages, use the paginated overload. */

--- a/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchMetaCategories.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchMetaCategories.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Search {
+extension Search {
 
     /** Gets the available search categories. */
     public enum SearchMetaCategories {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchMetaSearchProviders.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchMetaSearchProviders.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Search {
+extension Search {
 
     /** Gets the available searchProvider names. */
     public enum SearchMetaSearchProviders {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchMetaSorts.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Search/SearchMetaSorts.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Search {
+extension Search {
 
     /** Gets the available sorting options. */
     public enum SearchMetaSorts {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPoints.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPoints.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Search StopPoints by their common name, or their 5-digit Countdown Bus Stop Code. */
     public enum SearchStopPoints {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPointsByPath.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPointsByPath.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Search StopPoints by their common name, or their 5-digit Countdown Bus Stop Code. */
     public enum SearchStopPointsByPath {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointArrivals.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointArrivals.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets the list of arrival predictions for the given stop point id */
     public enum StopPointArrivals {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointCrowding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointCrowding.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets all the Crowding data (static) for the StopPointId, plus crowding data for a given line and optionally a particular direction. */
     public enum StopPointCrowding {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDirection.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDirection.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Returns the canonical direction, "inbound" or "outbound", for a given pair of stop point Ids in the direction from -> to. */
     public enum StopPointDirection {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruption.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets all disruptions for the specified StopPointId, plus disruptions for any child Naptan records it may have. */
     public enum StopPointDisruption {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruptionByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruptionByMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets a distinct list of disrupted stop points for the given modes */
     public enum StopPointDisruptionByMode {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets a list of StopPoints corresponding to the given list of stop ids. */
     public enum StopPointGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByGeoPoint.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByGeoPoint.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets a list of StopPoints within {radius} by the specified criteria */
     public enum StopPointGetByGeoPoint {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets a list of StopPoints filtered by the modes available at that StopPoint. */
     public enum StopPointGetByMode {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetBySms.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetBySms.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets a StopPoint for a given sms code. */
     public enum StopPointGetBySms {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByType.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets all stop points of a given type */
     public enum StopPointGetByType {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetCarParksById.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetCarParksById.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Get car parks corresponding to the given stop point id. */
     public enum StopPointGetCarParksById {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetServiceTypes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetServiceTypes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets the service types for a given stoppoint */
     public enum StopPointGetServiceTypes {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetTaxiRanksByIds.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetTaxiRanksByIds.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets a list of taxi ranks corresponding to the given stop point id. */
     public enum StopPointGetTaxiRanksByIds {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointMetaCategories.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointMetaCategories.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets the list of available StopPoint additional information categories */
     public enum StopPointMetaCategories {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointMetaModes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointMetaModes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets the list of available StopPoint modes */
     public enum StopPointMetaModes {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointMetaStopTypes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointMetaStopTypes.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets the list of available StopPoint types */
     public enum StopPointMetaStopTypes {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointReachableFrom.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointReachableFrom.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Gets Stopoints that are reachable from a station/line combination. */
     public enum StopPointReachableFrom {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointRoute.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.StopPoint {
+extension StopPoint {
 
     /** Returns the route sections for all the lines that service the given stop point ids */
     public enum StopPointRoute {

--- a/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetCompareOverlay.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetCompareOverlay.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.TravelTime {
+extension TravelTime {
 
     /** Gets the TravelTime overlay. */
     public enum TravelTimeGetCompareOverlay {

--- a/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetOverlay.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetOverlay.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.TravelTime {
+extension TravelTime {
 
     /** Gets the TravelTime overlay. */
     public enum TravelTimeGetOverlay {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Vehicle/VehicleGet.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Vehicle/VehicleGet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Vehicle {
+extension Vehicle {
 
     /** Gets the predictions for a given list of vehicle Id's. */
     public enum VehicleGet {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Vehicle/VehicleGetVehicle.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Vehicle/VehicleGetVehicle.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TFL.Vehicle {
+extension Vehicle {
 
     /** Gets the Emissions Surcharge compliance for the Vehicle */
     public enum VehicleGetVehicle {

--- a/Specs/TestSpec/generated/Swift/Sources/API.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/API.swift
@@ -5,8 +5,9 @@
 
 import Foundation
 
-public struct TestSpec {
+public let version = "1.0"
 
+public struct Config {
     /// Whether to discard any errors when decoding optional properties
     public static var safeOptionalDecoding = false
 
@@ -15,6 +16,21 @@ public struct TestSpec {
 
     /// Used to encode Dates when uses as string params
     public static let dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
-
-    public static let version = "1.0"
 }
+
+public enum Server {
+
+    /** Test environment **/
+    public static func test(space: String = "main", version: String = "v1") -> String {
+        var url = "https://test.petstore.com/{version}/{space}"
+        url = url.replacingOccurrences(of: "{\(space)}", with: space)
+        url = url.replacingOccurrences(of: "{\(version)}", with: version)
+        return url
+    }
+
+    /** Prod environment **/
+    public static let prod = "http://petstore.swagger.io/v1"
+}
+
+/// Tags
+public enum Operation {}

--- a/Specs/TestSpec/generated/Swift/Sources/Coding.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Coding.swift
@@ -111,7 +111,7 @@ extension KeyedDecodingContainer {
         do {
             container = try nestedUnkeyedContainer(forKey: key)
         } catch {
-            if TestSpec.safeArrayDecoding {
+            if Config.safeArrayDecoding {
                 return array
             } else {
                 throw error
@@ -123,7 +123,7 @@ extension KeyedDecodingContainer {
                 let element = try container.decode(T.self)
                 array.append(element)
             } catch {
-                if TestSpec.safeArrayDecoding {
+                if Config.safeArrayDecoding {
                     // hack to advance the current index
                     _ = try? container.decode(AnyCodable.self)
                 } else {
@@ -145,7 +145,7 @@ extension KeyedDecodingContainer {
     }
 
     fileprivate func decodeOptional<T>(_ closure: () throws -> T? ) throws -> T? {
-        if TestSpec.safeOptionalDecoding {
+        if Config.safeOptionalDecoding {
             do {
                 return try closure()
             } catch {
@@ -295,7 +295,7 @@ extension DateDay {
 
 extension Date {
     func encode() -> Any {
-        return TestSpec.dateEncodingFormatter.string(from: self)
+        return Config.dateEncodingFormatter.string(from: self)
     }
 }
 
@@ -323,7 +323,7 @@ extension Dictionary where Key == String, Value: RawRepresentable {
     }
 }
 
-extension UUID {
+extension Foundation.UUID {
     func encode() -> Any {
         return uuidString
     }

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/GetDefaultResponse.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/GetDefaultResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** operation with no responses */
     public enum GetDefaultResponse {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/GetInlineEnumResponse.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/GetInlineEnumResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** operation with an enum response */
     public enum GetInlineEnumResponse {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/GetMultipleParams.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/GetMultipleParams.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** Has path and operation parameters */
     public enum GetMultipleParams {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/GetMultipleSuccess.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/GetMultipleSuccess.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** operation with multiple success responses */
     public enum GetMultipleSuccess {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/GetString.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/GetString.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** operation with string response */
     public enum GetString {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/Pets.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/Pets.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** operation with a tag */
     public enum Pets {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/PostAllParams.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/PostAllParams.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** Has all sorts of parameters */
     public enum PostAllParams {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/PostInlinebody.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/PostInlinebody.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** operation with an inline body */
     public enum PostInlinebody {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/PostString.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/PostString.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** operation with string body */
     public enum PostString {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/UpdateWithForm.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/UpdateWithForm.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension TestSpec {
+extension Operation {
 
     /** Posts a form */
     public enum UpdateWithForm {

--- a/Templates/Swift/Sources/API.swift
+++ b/Templates/Swift/Sources/API.swift
@@ -5,8 +5,11 @@ import Foundation
 {% if info.description %}
 /** {{ info.description }} */
 {% endif %}
-public struct {{ options.name }} {
+{% if info.version %}
+public let version = "{{ info.version }}"
+{% endif %}
 
+public struct Config {
     /// Whether to discard any errors when decoding optional properties
     public static var safeOptionalDecoding = {% if options.safeOptionalDecoding %}true{% else %}false{% endif %}
 
@@ -15,39 +18,37 @@ public struct {{ options.name }} {
 
     /// Used to encode Dates when uses as string params
     public static let dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+}
 
-    {% if info.version %}
-    public static let version = "{{ info.version }}"
+{% if servers %}
+public enum Server {
+    {% for server in servers %}
+
+    {% if server.description %}
+    /** {{ server.description }} **/
     {% endif %}
-    {% if tags %}
-
-    {% for tag in tags %}
-    public enum {{ options.tagPrefix }}{{ tag|upperCamelCase }}{{ options.tagSuffix }} {}
-    {% endfor %}
-    {% if servers %}
-
-    public enum Server {
-        {% for server in servers %}
-        
-        {% if server.description %}
-        /** {{ server.description }} **/
-        {% endif %}
-        {% if server.variables %}
-        public static func {{ server.name }}({% for variable in server.variables %}{{ variable.name }}: String = "{{ variable.defaultValue}}"{% ifnot forloop.last %}, {% endif %}{% endfor %}) -> String {
-            var url = "{{ server.url }}"
-            {% for variable in server.variables %}
-            url = url.replacingOccurrences(of: "{\({{variable.name}})}", with: {{variable.name}})
-            {% endfor %}
-            return url
-        }
-        {% else %}
-        public static let {{ server.name }} = "{{ server.url }}"
-        {% endif %}
+    {% if server.variables %}
+    public static func {{ server.name }}({% for variable in server.variables %}{{ variable.name }}: String = "{{ variable.defaultValue}}"{% ifnot forloop.last %}, {% endif %}{% endfor %}) -> String {
+        var url = "{{ server.url }}"
+        {% for variable in server.variables %}
+        url = url.replacingOccurrences(of: "{\({{variable.name}})}", with: {{variable.name}})
         {% endfor %}
+        return url
     }
     {% else %}
-
-    // No servers defined in swagger. Documentation for adding them: https://swagger.io/specification/#schema
+    public static let {{ server.name }} = "{{ server.url }}"
     {% endif %}
-    {% endif %}
+    {% endfor %}
 }
+{% else %}
+/// No servers defined in swagger. Documentation for adding them: https://swagger.io/specification/#schema
+{% endif %}
+
+/// Tags
+{% if tags %}
+{% for tag in tags %}
+public enum {{ options.tagPrefix }}{{ tag|upperCamelCase }}{{ options.tagSuffix }} {}
+{% endfor %}
+{% else %}
+public enum Operation {}
+{% endif %}

--- a/Templates/Swift/Sources/Coding.swift
+++ b/Templates/Swift/Sources/Coding.swift
@@ -110,7 +110,7 @@ extension KeyedDecodingContainer {
         do {
             container = try nestedUnkeyedContainer(forKey: key)
         } catch {
-            if {{ options.name }}.safeArrayDecoding {
+            if Config.safeArrayDecoding {
                 return array
             } else {
                 throw error
@@ -122,7 +122,7 @@ extension KeyedDecodingContainer {
                 let element = try container.decode(T.self)
                 array.append(element)
             } catch {
-                if {{ options.name }}.safeArrayDecoding {
+                if Config.safeArrayDecoding {
                     // hack to advance the current index
                     _ = try? container.decode(AnyCodable.self)
                 } else {
@@ -144,7 +144,7 @@ extension KeyedDecodingContainer {
     }
 
     fileprivate func decodeOptional<T>(_ closure: () throws -> T? ) throws -> T? {
-        if {{ options.name }}.safeOptionalDecoding {
+        if Config.safeOptionalDecoding {
             do {
                 return try closure()
             } catch {
@@ -294,7 +294,7 @@ extension DateDay {
 
 extension Date {
     func encode() -> Any {
-        return {{ options.name }}.dateEncodingFormatter.string(from: self)
+        return Config.dateEncodingFormatter.string(from: self)
     }
 }
 
@@ -322,7 +322,7 @@ extension Dictionary where Key == String, Value: RawRepresentable {
     }
 }
 
-extension UUID {
+extension Foundation.UUID {
     func encode() -> Any {
         return uuidString
     }

--- a/Templates/Swift/Sources/Request.swift
+++ b/Templates/Swift/Sources/Request.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-extension {{ options.name }}{% if tag %}.{{ options.tagPrefix }}{{ tag|upperCamelCase }}{{ options.tagSuffix }}{% endif %} {
+extension {% if tag %}{{ options.tagPrefix }}{{ tag|upperCamelCase }}{{ options.tagSuffix }}{% else %}Operation{% endif %} {
 
     {% if description and summary %}
     {% if description == summary %}


### PR DESCRIPTION
Fix for yonaskolb#153

**Changes:**
- remove top level namespace
- move coding options into a new Config namespace
- pull tags, version and Server out to the top level
- if no tags, create Operation namespace

Newly generated API library should not have many braking changes - only references to coding options would need to be updated - references to operations should continue working via the old namespace as it matches the module name.

**Notes for reviewer:**

- the changes are only done to the Swift template Templates/
- the changes in fixtures Specs/ are automatically generated